### PR TITLE
Include performance_data in state output

### DIFF
--- a/nagios/core.py
+++ b/nagios/core.py
@@ -44,7 +44,14 @@ class Nagios:
                             chunks = dat.split(';', 1)
                             if chunks and len(chunks) > 0 and '=' in chunks[0]:
                                 (c_key, c_val) = chunks[0].split('=', 1)
-                                performance_data[c_key] = c_val
+                                # convert to int or float if possible
+                                try:
+                                    n_val = float(c_val)
+                                    if (n_val == int(n_val)):
+                                        n_val = int(n_val)
+                                except ValueError:
+                                    n_val = c_val
+                                performance_data[c_key] = n_val
                         val = performance_data
                     cur[key] = val
             if cur is not None:


### PR DESCRIPTION
Hello.
This is a simple patch to parse out the performance_data (if available) and deliver it along with the service state in nagios-api.

Here are some examples of how this is useful:

```
    "MongoDB Free Connections": {
      "active_checks_enabled": "1",
      "performance_data": {
        "used_percent": 0,
        "current_connections": 5,
        "available_connections": 814
      },
      "last_hard_state": "0",
      "notifications_enabled": "1",
      "current_state": "0",
      "downtimes": {},
      "plugin_output": "OK - 0 percent (5 of 819 connections) used",
      "last_check": "1345405191",
      "problem_has_been_acknowledged": "0",
      "comments": {},
      "scheduled_downtime_depth": "0",
      "last_notification": "0"
    },

    "MongoDB Flush Average": {
      "active_checks_enabled": "1",
      "performance_data": {
        "average_flush_time": "55.64ms"
      },
      "last_hard_state": "0",
      "notifications_enabled": "1",
      "current_state": "0",
      "downtimes": {},
      "plugin_output": "OK - Average Flush Time: 55.64ms",
      "last_check": "1345405697",
      "problem_has_been_acknowledged": "0",
      "comments": {},
      "scheduled_downtime_depth": "0",
      "last_notification": "0"
    },

    "Current Load": {
      "active_checks_enabled": "1",
      "performance_data": {
        "load1": 0.1,
        "load15": 1.05,
        "load5": 0.91
      },
      "last_hard_state": "0",
      "notifications_enabled": "1",
      "current_state": "0",
      "downtimes": {},
      "plugin_output": "OK - load average: 0.10, 0.91, 1.05",
      "last_check": "1345405138",
      "problem_has_been_acknowledged": "0",
      "comments": {},
      "scheduled_downtime_depth": "0",
      "last_notification": "0"
    },
```

Hope that makes sense. If not, please let me know, and I'll try again. (-:

S
