### PR TITLE
Add a few more essential_keys to return

### DIFF
--- a/nagios/core.py
+++ b/nagios/core.py
@@ -142,7 +142,8 @@ class HostOrService(NagiosObject):
         self.essential_keys = ['current_state', 'plugin_output',
             'notifications_enabled', 'last_check', 'last_notification',
             'active_checks_enabled', 'problem_has_been_acknowledged',
-            'last_hard_state', 'scheduled_downtime_depth', 'performance_data']
+            'last_hard_state', 'scheduled_downtime_depth', 'performance_data',
+            'last_state_change', 'current_attempt', 'max_attempts']
 
     def attach_downtime(self, dt):
         '''Given a Downtime object, store a record to it for lookup later.'''


### PR DESCRIPTION
These are required for my upcoming NagDash project which replaces the old Nagite2. (http://github.com/lozzd/Naglite2) 
Part of the information we want to display is how long a service has been in this state (thus last_state_change) 
and it also displays things that are about to alert (e.g. soft) so we need the number of attempts so far and the maximum attempts (which are also displayed)
