### PR TITLE
add --url to specify a full URL plus cosmetic fixes

### DIFF
--- a/nagios-cli
+++ b/nagios-cli
@@ -467,11 +467,16 @@ def main(argv):
     p.add_option('-H', '--host', dest='host', default='localhost',
         help='Host to connect to', metavar='HOST')
     p.add_option('-p', '--port', dest='port', type='int', default=6315,
-        help='Port to listen on', metavar='PORT')
+        help='Port to connect to', metavar='PORT')
+    p.add_option('-u', '--url', dest='url',
+        help='URL to use instead of host:port', metavar='URL')
     p.add_option('--raw', dest='raw', action='store_true',
         help='Enable raw mode for the CLI')
     (opts, args) = p.parse_args(argv[1:])
-    URL = 'http://%s:%d' % (opts.host, opts.port)
+    if opts.url:
+        URL = opts.url
+    else:
+        URL = 'http://%s:%d' % (opts.host, opts.port)
 
     # If no more arguments, show usage
     if len(args) <= 0:


### PR DESCRIPTION
Hi,
thanks for nagios-api!

I'm planning to reverse-proxy via apache on the same nagios box like I'm doing with nagios web interface at the moment so being able to specify an arbitrary url to nagios-cli comes handy.
