### PR TITLE
Initd file fixes

### DIFF
--- a/nagios-api-initd
+++ b/nagios-api-initd
@@ -15,7 +15,7 @@ source /etc/rc.d/init.d/functions
 PROG="nagios-api"
 DESC="Nagios API Daemon"
 RETVAL=0
-LOGFILE="/var/log/nagios-api.log"
+LOGFILE="/var/log/nagios/nagios-api.log"
 
 NAG_API_BIN=/usr/local/bin/nagios-api
 NAG_API_PORT=8181


### PR DESCRIPTION
Hello,

I've modified the init.d script to use more of the SysV functions to work like the other scripts and added some variables to configure where Nagios files are. Right now the variables are pointing to where the Nagios package on CentOS points to.
