### PR TITLE
I thought I was introducing an optimization be ensuring we didn't needlessly loop over multiple keys. Turns out, I introduced a bug that prevents the API from seeing multiple downtimes for a given host.

### DIFF
--- a/nagios-api
+++ b/nagios-api
@@ -124,6 +124,8 @@ def http_host(req, objid, reqobj):
     elif objid not in NAGIOS.hosts.keys():
         return json_error(req, 'Unknown hostname.')
     ret = {}
+    ret['comment'] = []
+    ret['downtime'] = []
     host_keys = [ x for x in dir(NAGIOS.hosts[objid]) if not x.startswith('__') ]
     for host_key in host_keys:
         value = getattr(NAGIOS.hosts[objid], host_key)
@@ -133,9 +135,9 @@ def http_host(req, objid, reqobj):
         elif type(value) == dict:
             for k, v in value.iteritems():
                 if isinstance( v, Comment ):
-                    ret["comment"] = v.for_json()
+                    ret['comment'].append( v.for_json() )
                 elif isinstance( v, Downtime ):
-                    ret["downtime"] = v.for_json()
+                    ret['downtime'].append( v.for_json() )
     if objid in NAGIOS.services:
         ret['services'] = []
         for svc in NAGIOS.services[objid]:


### PR DESCRIPTION
... object.  If there are multiple Comment or Downtime objects, we need to see them.
