### PR TITLE
Read log block

### DIFF
--- a/nagios-api
+++ b/nagios-api
@@ -19,6 +19,7 @@ import datetime
 import os
 import re
 import sys
+import threading
 import time
 import types
 import atexit
@@ -908,7 +909,8 @@ def main(argv):
     app.add_loop(Loop(read_status, options.statusfile), keep_alive=True)
     if os.path.isfile(options.logfile):
         LOG_ENABLED = True
-        app.add_loop(Loop(read_log, options.logfile), keep_alive=True)
+        thread = threading.Thread(target=read_log, args=(options.logfile,))
+        thread.start()
     app.run()
     return 1
 

--- a/nagios-api-initd
+++ b/nagios-api-initd
@@ -17,13 +17,13 @@ DESC="Nagios API Daemon"
 RETVAL=0
 LOGFILE="/var/log/nagios/nagios-api.log"
 
-NAG_API_BIN=/usr/local/bin/nagios-api
-NAG_API_PORT=8181
+NAG_API_BIN=/usr/bin/nagios-api
+NAG_API_PORT=6315
 NAG_API_PID=/var/run/$PROG.pid
 
-NAGIOS_STATUS_FILE=/var/nagios/status.dat
-NAGIOS_COMMAND_FILE=/var/nagios/rw/nagios.cmd
-NAGIOS_LOG_FILE=/var/log/nagios.log
+NAGIOS_STATUS_FILE=/var/log/nagios/status.dat
+NAGIOS_COMMAND_FILE=/var/spool/nagios/cmd/nagios.cmd
+NAGIOS_LOG_FILE=/var/log/nagios/nagios.log
 
 start() {
   echo -n "Starting $DESC ($PROG): "


### PR DESCRIPTION
Fixes blocking function of read_log consuming too slowly in larger nagios installations by putting the function into its own thread.  sleep(1) kept to avoid busy loop.