### PR TITLE
Use pyOpenSSL >= 0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ diesel==3.0.24
 dnspython==1.11.1
 greenlet==0.4.0
 http-parser==0.8.1
-pyOpenSSL==0.13
+pyOpenSSL==0.14
 requests==1.2.0


### PR DESCRIPTION
For more details see: https://github.com/pyca/pyopenssl/issues/276