### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:16.04
+MAINTAINER Rogier Slag <rogier@inventid.nl>
+
+EXPOSE 8080
+# The following files can be mapped into the container for usages towards Nagios
+# However setting these as a volume causes Docker to create directories for them
+# VOLUME ["/opt/status.dat", "/opt/nagios.cmd", "/opt/nagios.log"]
+
+RUN apt-get update && \
+    apt-get install python-virtualenv libffi-dev python-dev python-pip python-setuptools openssl libssl-dev -y
+RUN cd /opt && \
+    virtualenv env && \
+    /opt/env/bin/pip install diesel && \
+    /opt/env/bin/pip install requests
+
+RUN mkdir /opt/nagios-api
+COPY . /opt/nagios-api
+
+CMD ["/opt/env/bin/python", "/opt/nagios-api/nagios-api", "-p", "8080", "-s", "/opt/status.dat", "-c", "/opt/nagios.cmd", "-l", "/opt/nagios.log", "-q"]
+

--- a/README
+++ b/README
@@ -398,6 +398,23 @@ Nagios.
 The response indicates if we successfully wrote the command to the log.
 
 
+DOCKER
+------
+
+A Docker container is available for convenience. It needs to be run on
+the same server as the nagios installation.
+
+First determine the location of the `status.dat`, `nagios.log`, and
+`nagios.cmd` files. Map these files into the Docker container. The
+container can be started using the following command:
+
+`docker run -v /var/lib/nagios3/rw/nagios.cmd:/opt/nagios.cmd \
+-v /var/cache/nagios3/status.dat:/opt/status.dat \
+-v /var/log/nagios3/nagios.log:/opt/nagios.log \
+-p 2337:8080 inventid/nagios-python-api`
+
+In the above case, the API will be exposed on port 2337.
+
 AUTHOR
 ------
 Written by Mark Smith <mark@qq.is> while under the employ of Bump


### PR DESCRIPTION
In order to easily run the api plugin on our infrastructure, I dockerized the build. This allows you to easily run the container on your nagios host, without having to install Python or any other dependencies on the hosts themselves.

Since it might be useful for others, here's a Pull Request for it