### PR TITLE
when a string is not found in a line, we do not always get a float back

### DIFF
--- a/nagios/core.py
+++ b/nagios/core.py
@@ -55,7 +55,7 @@ class Nagios:
                         val = performance_data
                     cur[key] = val
                 elif "#" in line:
-                    if line.find("NAGIOS STATE RETENTION FILE") is not -1.0:
+                    if not line.find("NAGIOS STATE RETENTION FILE"):
                         raise ValueError("You appear to have used the state retention file instead of the status file. Please change your arguments and try again.")
             if cur is not None:
                 yield cur


### PR DESCRIPTION
I found that I got errors about the status file not being a status file even when it was (eh?). This should fix that. Also see #69 