### PR TITLE
Install dependancies for nagios-api when installed via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ setup(name='nagios-api',
       url='https://github.com/xb95/nagios-api',
       packages=['nagios'],
       scripts=['nagios-cli', 'nagios-api'],
-      requires=[
-        'diesel(>=3.0)',
-        'greenlet(==0.3.4)',
+      install_requires=[
+        'diesel>=3.0',
+        'greenlet==0.3.4',
         'requests'
       ]
      )


### PR DESCRIPTION
Currently, installing `nagios-api` via pip from PyPI doesn't result in a working installation because `setup.py` doesn't specify the required dependencies. 

By using the setuptools [`install_requires`](http://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords) keyword, the dependencies will be installed automatically. 

This should partially address issue #51. 