### PR TITLE
Updated pyOpenSSL dependency to 16.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ diesel==3.0.24
 dnspython==1.11.1
 greenlet==0.4.0
 http-parser==0.8.1
-pyOpenSSL==0.14
+pyOpenSSL==16.2.0
 requests==1.2.0


### PR DESCRIPTION
This fixes an `AttributeError: 'module' object has no attribute 'SSL_ST_INIT'` error on startup.